### PR TITLE
updated validate-ctv GHA with improved performance

### DIFF
--- a/.github/workflows/validate-ctv.yml
+++ b/.github/workflows/validate-ctv.yml
@@ -19,5 +19,7 @@ name: Validate task view
 jobs:
   validate-ctv:
     runs-on: ubuntu-latest
+    container:
+      image: rocker/r2u:latest
     steps:
       - uses: cran-task-views/ctv/validate-ctv@main

--- a/NetworkAnalysis.md
+++ b/NetworkAnalysis.md
@@ -3,7 +3,7 @@ name: NetworkAnalysis
 topic: Network Analysis
 maintainer: Fabio Ashtar Telarico, Pavel N. Krivitsky, James Hollway
 email: Fabio-Ashtar.Telarico@fdv.uni-lj.si
-version: 2025-09-14
+version: 2025-09-24
 source: https://github.com/cran-task-views/NetworkAnalysis/
 ---
 


### PR DESCRIPTION
Hi, we have updated our [cran-task-views/ctv/validate-ctv](https://github.com/cran-task-views/ctv/blob/main/validate-ctv/action.yml) GitHub action. It now uses the `rocker/r2u` container which speeds up running the action. Also, we have streamlined the R code of the action a bit.

For the action to work correctly a small addition in the `validate-ctv` workflow of your repository is necessary, namely declaring the `rocker/r2u` container. This is what this PR provides. Let us know if anything is unclear.